### PR TITLE
Fix corrupted output in certain cases

### DIFF
--- a/src/DotNet.Property/ProjectUpdater.cs
+++ b/src/DotNet.Property/ProjectUpdater.cs
@@ -102,7 +102,7 @@ namespace DotNet.Property
                 Indent = true
             };
 
-            using (var stream = File.OpenWrite(filePath))
+            using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
             using (var writer = XmlWriter.Create(stream, settings))
             {
                 document.Save(writer);


### PR DESCRIPTION
When the output is coincidentally shorter than the original input, the resulting file will not contain valid XML. This is because `File.OpenWrite` will not remove the contents of the old file before writing, and the end of the previous version of the file will still be present in the new file.

This will fix #1 